### PR TITLE
Fix link to VKCOM/kphp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-I'm currently working on [NoVerify](https://github.com/VKCOM/noverify) and [KPHP compiler](github.com/VKCOM/kphp/) at [vk.com](https://github.com/VKCOM/).
+I'm currently working on [NoVerify](https://github.com/VKCOM/noverify) and [KPHP compiler](https://github.com/VKCOM/kphp/) at [vk.com](https://github.com/VKCOM/).
 
 I was involved in [golang/go](https://github.com/golang/go/commits?author=quasilyte) and [golang/arch](https://github.com/golang/arch/commits?author=quasilyte) development in the past.<br>
 I try to maintain several<sup>[[1]](https://go-critic.github.io/)</sup> good<sup>[[2]](https://github.com/VKCOM/noverify)</sup> static<sup>[[3]](https://github.com/quasilyte/go-consistent)</sup> analyzers<sup>[[4]](https://github.com/quasilyte/go-ruleguard)</sup>.<br>


### PR DESCRIPTION
**Problem:** 
Link to vkcom/kphp refers to https://github.com/quasilyte/quasilyte/blob/master/github.com/VKCOM/kphp

**Solution:** 
Add protocol (https://)

**Demo:**
See at https://github.com/char16t/quasilyte/tree/patch-1